### PR TITLE
non-english reviews, empty event

### DIFF
--- a/lib/app-store-reviews.js
+++ b/lib/app-store-reviews.js
@@ -13,7 +13,7 @@ function AppStoreReviews() {
 
 AppStoreReviews.prototype.getReviews = function (app, country, page) {
 	var self = this;
-	var url = 'http://itunes.apple.com/rss/customerreviews/page=' + page + '/id=' + app + '/sortby=mostrecent/json?l=en&cc=' + country;
+	var url = 'http://itunes.apple.com/rss/customerreviews/page=' + page + '/id=' + app + '/sortby=mostrecent/json?cc=' + country;
 	
 	request(url, function (error, response, body) {
 		if (!error && response.statusCode == 200) {

--- a/lib/app-store-reviews.js
+++ b/lib/app-store-reviews.js
@@ -70,6 +70,8 @@ AppStoreReviews.prototype.getReviews = function (app, country, page) {
 						}
 					}
 				}
+			} else {
+				self.emit('empty', data['feed']['id']['label']);
 			}
 		}
 	});


### PR DESCRIPTION
## Non-english reviews

Language parameter was set to english, which caused the reviews to come back empty when using non-US app stores

## Empty event

It's useful to understand when there are no more reviews to fetch, an end event makes this possible