### PR TITLE
Added DONE event for notification of when all pages have been fetched

### DIFF
--- a/lib/app-store-reviews.js
+++ b/lib/app-store-reviews.js
@@ -88,6 +88,9 @@ AppStoreReviews.prototype.getReviews = function (app, country, page) {
 				self.emit('empty', data['feed']['id'][0]);
 			}
 		}
+    else {
+      self.emit('error', {error:error, response:response, body:body});
+    }
 	});
 }
 

--- a/lib/app-store-reviews.js
+++ b/lib/app-store-reviews.js
@@ -1,9 +1,10 @@
-// Copyright (c) 2013-2015 Jules Coynel
+// Copyright (c) 2013-2017 Jules Coynel
 // https://github.com/jcoynel/app-store-reviews
 
 var EventEmitter = require('events').EventEmitter;
 var Util = require('util');
 var request = require('request');
+var parseString = require('xml2js').parseString;
 
 module.exports = AppStoreReviews;
 Util.inherits(AppStoreReviews, EventEmitter);
@@ -13,72 +14,85 @@ function AppStoreReviews() {
 
 AppStoreReviews.prototype.getReviews = function (app, country, page) {
 	var self = this;
-	var url = 'http://itunes.apple.com/rss/customerreviews/page=' + page + '/id=' + app + '/sortby=mostrecent/json?cc=' + country;
-	
+	var url = 'https://itunes.apple.com/rss/customerreviews/page=' + page + '/id=' + app + '/sortby=mostrecent/xml?cc=' + country;
+  var hasNextPage = false;
+  var lastPage;
+
 	request(url, function (error, response, body) {
 		if (!error && response.statusCode == 200) {
-			var data = JSON.parse(body);		
+			var data;
+			parseString(body, function (err, result) {
+				data = result;
+				if (err) {
+					console.log(err)
+				}
+			});
+
 			var entry = data['feed']['entry'];
 			var links = data['feed']['link'];
-			
+
 			if (entry && links) {
 				for (var i = 0; i < entry.length ;i++) {
 					var rawReview = entry[i];
-					if ('content' in rawReview) {	
-						try
-						{		
+					if ('author' in rawReview) {
+						try {
 							var comment = [];
-							comment['id'] = rawReview['id']['label'];
+							comment['id'] = rawReview['id'][0];
 							comment['app'] = app;
-							comment['author'] = rawReview['author']['name']['label'];
-							comment['version'] = rawReview['im:version']['label'];
-							comment['rate'] = rawReview['im:rating']['label'];
-							comment['title'] = rawReview['title']['label'];
-							comment['comment'] = rawReview['content']['label'];
-							comment['vote'] = rawReview['im:voteCount']['label'];
+							comment['author'] = rawReview['author'][0]['name'][0];
+							comment['version'] = rawReview['im:version'][0];
+							comment['rate'] = rawReview['im:rating'][0];
+							comment['title'] = rawReview['title'][0];
+							comment['comment'] = rawReview['content'][0]['_'];
+							comment['vote'] = rawReview['im:voteCount'][0];
+							comment['updated'] = rawReview['updated'][0];
 							comment['country'] = country;
-							
+
 							self.emit('review', comment);
-                       }
-                       catch (err) 
-                       {
-	                       console.log(err);
-                       }
+						} catch (err) {
+							console.log(err);
+						}
 					}
 				}
-				
+
 				/*
 				Because there are only 50 reviews per page, we need to find out if there is a next page.
 				If so, we emit a 'nextPage' event.
 				*/
 				for (var i = 0; i < links.length; i++) {
-					var link = links[i]['attributes'];
+					var link = links[i]['$'];
 					var rel = link['rel'];
 					var href = link['href'];
-					
-					// Find the last page number
+
+          // Find the last page number
 					if (rel == 'last') {
 						var urlSplit = href.split('/');
 						for (var index = 0; index < urlSplit.length; index++) {
 							var currentUrlPart = urlSplit[index];
 							if (currentUrlPart.substring(0, 5) == 'page=') {
-								var lastPage = currentUrlPart.replace('page=', '');
+								lastPage = currentUrlPart.replace('page=', '');
 								if (page < lastPage) {
-									self.emit('nextPage', {'appId': app, 'country': country, 'currentPage': page, 'nextPage': page + 1});
+                  hasNextPage = true;
+									self.emit('nextPage', {'appId': app, 'country': country, 'currentPage': page, 'nextPage': page + 1, 'lastPage': lastPage});
 								}
 							}
 						}
 					}
 				}
+
+        if (page == lastPage && !hasNextPage) {
+          self.emit('done', {'appId': app, 'country': country, 'currentPage': page, 'lastPage': lastPage});
+        }
+
 			} else {
-				self.emit('empty', data['feed']['id']['label']);
+				self.emit('empty', data['feed']['id'][0]);
 			}
 		}
 	});
 }
 
 AppStoreReviews.prototype.allCountries = function () {
-	// Based on http://developer.apple.com/library/ios/#documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/C_AppStoreTerritories/AppStoreTerritories.html
-	// Updated on 23 April 2013
+	// Based on https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/AppStoreTerritories.html
+	// Updated on 16 June 2017
 	return ['ae', 'ag', 'ai', 'al', 'am', 'ao', 'ar', 'at', 'au', 'az', 'bb', 'be', 'bf', 'bg', 'bh', 'bj', 'bm', 'bn', 'bo', 'br', 'bs', 'bt', 'bw', 'by', 'bz', 'ca', 'cg', 'ch', 'cl', 'cn', 'co', 'cr', 'cv', 'cy', 'cz', 'de', 'dk', 'dm', 'do', 'dz', 'ec', 'ee', 'eg', 'es', 'fi', 'fj', 'fm', 'fr', 'gb', 'gd', 'gh', 'gm', 'gr', 'gt', 'gw', 'gy', 'hk', 'hn', 'hr', 'hu', 'id', 'ie', 'il', 'in', 'is', 'it', 'jm', 'jo', 'jp', 'ke', 'kg', 'kh', 'kn', 'kr', 'kw', 'ky', 'kz', 'la', 'lb', 'lc', 'lk', 'lr', 'lt', 'lu', 'lv', 'md', 'mg', 'mk', 'ml', 'mn', 'mo', 'mr', 'ms', 'mt', 'mu', 'mw', 'mx', 'my', 'mz', 'na', 'ne', 'ng', 'ni', 'nl', 'no', 'np', 'nz', 'om', 'pa', 'pe', 'pg', 'ph', 'pk', 'pl', 'pt', 'pw', 'py', 'qa', 'ro', 'ru', 'sa', 'sb', 'sc', 'se', 'sg', 'si', 'sk', 'sl', 'sn', 'sr', 'st', 'sv', 'sz', 'tc', 'td', 'th', 'tj', 'tm', 'tn', 'tr', 'tt', 'tw', 'tz', 'ua', 'ug', 'us', 'uy', 'uz', 'vc', 've', 'vg', 'vn', 'ye', 'za', 'zw'];
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   },
   "homepage": "https://github.com/jcoynel/app-store-reviews",
   "dependencies": {
-    "request": ">=2.0.0"
+    "request": ">=2.0.0",
+    "xml2js": "*"
   },
   "repository": {
     "type": "git",

--- a/tests/reviews-done-event.js
+++ b/tests/reviews-done-event.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2013-2015 Jules Coynel
+// https://github.com/jcoynel/app-store-reviews
+
+/*
+Node.js modules required
+	- app-store-reviews
+	- mysql
+*/
+
+var appStoreReviewsModule = require('../lib/app-store-reviews');
+var appStoreReviews = new appStoreReviewsModule();
+
+appStoreReviews.on('done', function(data) {
+  console.log("Retrieved reviews for pages", data["currentPage"],"of", data["lastPage"]);
+  console.log("DONE", data);
+});
+
+appStoreReviews.on('nextPage', function(nextPage) {
+   console.log("Retrieved reviews for pages", nextPage["currentPage"],"of", nextPage["lastPage"]);
+	 appStoreReviews.getReviews(nextPage['appId'], nextPage['country'], nextPage['nextPage']);
+});
+
+
+console.log("Starting reviews-done-event.js at " + Date());
+
+// Parameters: appid, country, page
+appStoreReviews.getReviews("1111710488", "us", 1);


### PR DESCRIPTION
I added a done event which gets triggered when all nextPage's have been fetched. Created a tests folder to house any future tests. Also noticed that xml2js was missing when I did npm install, so I added it to the dependencies.

getReviews must be called recursively in order for the done event to be emitted as such: 

```
var appStoreReviewsModule = require('app-store-reviews');
var appStoreReviews = new appStoreReviewsModule();

appStoreReviews.on('nextPage', function(nextPage) {	 
    appStoreReviews.getReviews(nextPage['appId'], nextPage['country'], nextPage['nextPage']);
});

appStoreReviews.on('done', function(data) {	 
    console.log("DONE")
});

appStoreReviews.getReviews("1111710488", "us", 1);
```
